### PR TITLE
Add files via upload

### DIFF
--- a/ReportingServicesTools/Functions/Common/Get-ItemType.ps1
+++ b/ReportingServicesTools/Functions/Common/Get-ItemType.ps1
@@ -6,15 +6,16 @@
     )
     switch ($FileExtension)
     {
-        '.rdl'  { return 'Report' }
-        '.rsds' { return 'DataSource' }
-        '.rds' { return 'DataSource' }
-        '.rsd'  { return 'DataSet' }
+        '.rdl'      { return 'Report' }
+        '.rsds'     { return 'DataSource' }
+        '.rds'      { return 'DataSource' }
+        '.rsd'      { return 'DataSet' }
         '.rsmobile' { return 'MobileReport' }
-        '.pbix' { return 'PowerBIReport' }
-        '.xls' { return 'ExcelWorkbook' }
-        '.xlsx' { return 'ExcelWorkbook' }
-        '.kpi' { return 'Kpi' }
-        default { return 'Resource' }
+        '.pbix'     { return 'PowerBIReport' }
+        '.xls'      { return 'ExcelWorkbook' }
+        '.xlsx'     { return 'ExcelWorkbook' }
+        '.xlsm'     { return 'ExcelWorkbook' }
+        '.kpi'      { return 'Kpi' }
+        default     { return 'Resource' }
     }
 }


### PR DESCRIPTION
Add .xlsm (Microsoft Excel macro-enabled spreadsheet) to the type lookup. XLSM files are supported by Power BI but until now they could not be uploaded, refer to issue #349

Fixes #349.

Changes proposed in this pull request:
 - Adds a single line to Get-ItemType.ps1 for the .xlsm file type
 - Minor reformat of layout (spacing) for neatness

How to test this code:
 - Create an .xlsm file in Excel
 - Upload the file using `Write-RsRestCatalogItem -ReportPortalURI $youruri -Path 'C:\Temp\Just_a_test2.xlsm' -RsFolder $DestFolder'
Previously this would fail with an error message - (400) Bad Request. After this change to Get-ItemType.ps1 it seems to run without any issues.

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows Server 2016